### PR TITLE
Fix Abstract Title

### DIFF
--- a/src/jats/__tests__/__snapshots__/jats-importer.test.ts.snap
+++ b/src/jats/__tests__/__snapshots__/jats-importer.test.ts.snap
@@ -4754,7 +4754,7 @@ Object {
               },
               "content": Array [
                 Object {
-                  "text": "Teaser Abstract",
+                  "text": "Teaser: Heads up!",
                   "type": "text",
                 },
               ],
@@ -4762,76 +4762,18 @@ Object {
             },
             Object {
               "attrs": Object {
-                "dataTracked": null,
-              },
-              "content": Array [
-                Object {
-                  "attrs": Object {
-                    "dataTracked": null,
-                  },
-                  "content": Array [
-                    Object {
-                      "text": "Teaser: Heads up!",
-                      "type": "text",
-                    },
-                  ],
-                  "type": "section_title",
-                },
-                Object {
-                  "attrs": Object {
-                    "contents": "",
-                    "dataTracked": null,
-                    "paragraphStyle": "",
-                  },
-                  "content": Array [
-                    Object {
-                      "attrs": Object {
-                        "author": undefined,
-                        "containerTitle": undefined,
-                        "dataTracked": null,
-                        "doi": undefined,
-                        "issue": undefined,
-                        "issued": undefined,
-                        "literal": undefined,
-                        "page": undefined,
-                        "paragraphStyle": "",
-                        "supplement": undefined,
-                        "title": undefined,
-                        "type": undefined,
-                        "volume": undefined,
-                      },
-                      "type": "bibliography_item",
-                    },
-                  ],
-                  "type": "bibliography_element",
-                },
-              ],
-              "type": "bibliography_section",
-            },
-            Object {
-              "attrs": Object {
-                "category": "",
                 "comments": null,
                 "dataTracked": null,
-                "generatedLabel": undefined,
-                "pageBreakStyle": undefined,
-                "titleSuppressed": false,
+                "paragraphStyle": "",
+                "placeholder": "",
               },
               "content": Array [
                 Object {
-                  "attrs": Object {
-                    "dataTracked": null,
-                  },
-                  "content": Array [
-                    Object {
-                      "text": "The direct interaction of phenobarbital with the epidermal growth factor receptor reveals a new network interface in nuclear receptor signaling.",
-                      "type": "text",
-                    },
-                  ],
-                  "type": "section_title",
+                  "text": "The direct interaction of phenobarbital with the epidermal growth factor receptor reveals a new network interface in nuclear receptor signaling.",
+                  "type": "text",
                 },
               ],
-              "type": "section",
+              "type": "paragraph",
             },
           ],
           "type": "section",

--- a/src/jats/importer/jats-body-transformations.ts
+++ b/src/jats/importer/jats-body-transformations.ts
@@ -91,11 +91,13 @@ export const jatsBodyTransformations = {
     const sectionType = abstractType ? `abstract-${abstractType}` : 'abstract'
     section.setAttribute('sec-type', sectionType)
 
-    const title = createElement('title')
-    title.textContent = abstractType
-      ? `${capitalizeFirstLetter(abstractType)} Abstract`
-      : 'Abstract'
-    section.appendChild(title)
+    if (!abstractNode.querySelector('abstract > title')) {
+      const title = createElement('title')
+      title.textContent = abstractType
+        ? `${capitalizeFirstLetter(abstractType)} Abstract`
+        : 'Abstract'
+      section.appendChild(title)
+    }
 
     while (abstractNode.firstChild) {
       section.appendChild(abstractNode.firstChild)


### PR DESCRIPTION
some abstract section like this [one](https://github.com/Atypon-OpenSource/manuscripts-transform/blob/master/src/jats/__tests__/__fixtures__/jats-example-full.xml#L44) will end up to be a bibliography section. 