### PR TITLE
Fix figure labels in the content - LEAN-2985

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/transform",
   "description": "ProseMirror transformer for Manuscripts applications",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "repository": "github:Atypon-OpenSource/manuscripts-transform",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/transform",
   "description": "ProseMirror transformer for Manuscripts applications",
-  "version": "1.5.1-LEAN-2985-1",
+  "version": "1.5.1",
   "repository": "github:Atypon-OpenSource/manuscripts-transform",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/transform",
   "description": "ProseMirror transformer for Manuscripts applications",
-  "version": "1.5.1-LEAN-2985-0",
+  "version": "1.5.1-LEAN-2985-1",
   "repository": "github:Atypon-OpenSource/manuscripts-transform",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/transformer/labels.ts
+++ b/src/transformer/labels.ts
@@ -88,7 +88,7 @@ export const buildTargets = (
 
   const targets: Map<string, Target> = new Map()
   const figures: string[] = []
-  fragment.forEach((node) => {
+  fragment.descendants((node) => {
     if (node.type === node.type.schema.nodes.graphical_abstract_section) {
       node.forEach((item) => {
         if (item.type === node.type.schema.nodes.figure_element) {

--- a/src/transformer/labels.ts
+++ b/src/transformer/labels.ts
@@ -88,11 +88,15 @@ export const buildTargets = (
 
   const targets: Map<string, Target> = new Map()
   const figures: string[] = []
-  fragment.descendants((node) => {
-    if (node.type === node.type.schema.nodes.graphical_abstract_section) {
-      node.forEach((item) => {
-        if (item.type === node.type.schema.nodes.figure_element) {
-          figures.push(item.attrs.id)
+  fragment.forEach((node) => {
+    if (node.attrs.category === 'MPSectionCategory:abstracts') {
+      node.forEach((child) => {
+        if (child.type === node.type.schema.nodes.graphical_abstract_section) {
+          child.forEach((item) => {
+            if (item.type === node.type.schema.nodes.figure_element) {
+              figures.push(item.attrs.id)
+            }
+          })
         }
       })
     }


### PR DESCRIPTION
**Problem**: Figure number (label) in the content is incorrect when having a graphical Abstract. The graphical abstract figure element is also counted and this causes confusion.

**Expected**: The graphical abstract figure should not be labeled nor counted (affect other figures labels). i.e. if we have a figure before and a figure after the graphical abstract figure, the figure before should have a `Figure 1`label, and the figure after should have a `Figure 2` label.

**Solution**: Exclude the graphical abstract figure elements. While implementation is already supported, it was encountering issues in locating graphical abstract figures due to recent document structure updates. Consequently, I had to look for graphical_abstract nodes more deeply.