### PR TITLE
Fix table selection

### DIFF
--- a/src/schema/nodes/table_col.ts
+++ b/src/schema/nodes/table_col.ts
@@ -16,19 +16,19 @@
 
 // adapted from 'prosemirror-tables'
 
-import { ManuscriptNode, TableNodeSpec } from '../types'
+import { NodeSpec } from 'prosemirror-model'
 
-export type TableColGroupNode = ManuscriptNode
+import { ManuscriptNode } from '../types'
+
 export interface TableColNode extends ManuscriptNode {
   attrs: {
     width: string
   }
 }
 
-export const tableColGroup: TableNodeSpec = {
+export const tableColGroup: NodeSpec = {
   content: 'table_col+',
   group: 'block',
-  tableRole: 'colgroup',
   parseDOM: [
     {
       tag: 'colgroup',
@@ -39,12 +39,11 @@ export const tableColGroup: TableNodeSpec = {
   },
 }
 
-export const tableCol: TableNodeSpec = {
+export const tableCol: NodeSpec = {
   attrs: {
     width: { default: '' },
   },
   group: 'block',
-  tableRole: 'col',
   parseDOM: [
     {
       tag: 'col',


### PR DESCRIPTION
This PR will remove `tableRole` from `table_colgroup` node as we move this node from table to table_element in this [PR](https://github.com/Atypon-OpenSource/manuscripts-transform/pull/70/files#diff-6940b5da4550e030b6a6e66795da82c53cf4b1fc46a8a6a57331948b63f90dbbR41), keeping that attribute will build wrong table selection in [tablemap](https://github.com/ProseMirror/prosemirror-tables/blob/67371611fa9964c20d7d8be741f88ea8b3c24900/src/tablemap.ts#L234).