### PR TITLE
Newly Added Text Incorrectly Highlighted as Comment (LEAN-3509)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/transform",
   "description": "ProseMirror transformer for Manuscripts applications",
-  "version": "2.1.12",
+  "version": "2.1.12-LEAN-3509-0",
   "repository": "github:Atypon-OpenSource/manuscripts-transform",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/schema/nodes/highlight_marker.ts
+++ b/src/schema/nodes/highlight_marker.ts
@@ -23,7 +23,7 @@ interface Attrs {
   //target id
   tid: string
   position: string
-  text: string
+  content?: string
 }
 
 export interface HighlightMarkerNode extends ManuscriptNode {
@@ -39,6 +39,7 @@ export const highlightMarker: NodeSpec = {
     id: { default: '' },
     tid: { default: '' },
     position: { default: '' },
+    content: { default: null },
     dataTracked: { default: null },
   },
   parseDOM: [
@@ -51,20 +52,14 @@ export const highlightMarker: NodeSpec = {
           id: dom.getAttribute('id'),
           tid: dom.getAttribute('data-target-id'),
           position: dom.getAttribute('data-position'),
+          content: dom.innerHTML,
         }
       },
     },
   ],
   toDOM: (node) => {
     const highlightMarkerNode = node as HighlightMarkerNode
-
-    const dom = document.createElement('span')
-    dom.className = 'highlight-marker'
-    dom.setAttribute('id', highlightMarkerNode.attrs.id)
-    dom.setAttribute('data-target-id', highlightMarkerNode.attrs.tid)
-    dom.setAttribute('data-position', highlightMarkerNode.attrs.position)
-
-    return dom
+    return highlightMarkerNode.attrs.content || ''
   },
 }
 

--- a/src/transformer/__tests__/__snapshots__/decode.test.ts.snap
+++ b/src/transformer/__tests__/__snapshots__/decode.test.ts.snap
@@ -6183,22 +6183,10 @@ Object {
                 },
                 Object {
                   "attrs": Object {
+                    "content": "highlight",
                     "dataTracked": null,
                     "id": "MPCommentAnnotation:test2",
-                    "position": "start",
-                    "tid": "MPSection:1",
-                  },
-                  "type": "highlight_marker",
-                },
-                Object {
-                  "text": "highlight",
-                  "type": "text",
-                },
-                Object {
-                  "attrs": Object {
-                    "dataTracked": null,
-                    "id": "MPCommentAnnotation:test2",
-                    "position": "end",
+                    "position": "range",
                     "tid": "MPSection:1",
                   },
                   "type": "highlight_marker",
@@ -6223,22 +6211,10 @@ Object {
                 },
                 Object {
                   "attrs": Object {
+                    "content": "highlight",
                     "dataTracked": null,
                     "id": "MPCommentAnnotation:test",
-                    "position": "start",
-                    "tid": "MPParagraphElement:1",
-                  },
-                  "type": "highlight_marker",
-                },
-                Object {
-                  "text": "highlight",
-                  "type": "text",
-                },
-                Object {
-                  "attrs": Object {
-                    "dataTracked": null,
-                    "id": "MPCommentAnnotation:test",
-                    "position": "end",
+                    "position": "range",
                     "tid": "MPParagraphElement:1",
                   },
                   "type": "highlight_marker",

--- a/src/transformer/highlight-markers.ts
+++ b/src/transformer/highlight-markers.ts
@@ -140,14 +140,14 @@ export const insertHighlightMarkers = (
     if (comment.selector) {
       if (comment.selector.from === comment.selector.to) {
         element = createHighlightElement(comment, 'point')
-        output = injectHighlightMarker(element, comment.selector.from, output)
+        output = injectHighlightMarker(element, comment.selector, output)
       } else {
-        element = createHighlightElement(comment, 'start')
-        output = injectHighlightMarker(element, comment.selector.from, output)
-
-        const updatedEndOffset = element.outerHTML.length + comment.selector.to
-        element = createHighlightElement(comment, 'end')
-        output = injectHighlightMarker(element, updatedEndOffset, output)
+        element = createHighlightElement(
+          comment,
+          'range',
+          output.substring(comment.selector.from, comment.selector.to)
+        )
+        output = injectHighlightMarker(element, comment.selector, output)
       }
     }
   }
@@ -156,13 +156,17 @@ export const insertHighlightMarkers = (
 
 function injectHighlightMarker(
   element: HTMLElement,
-  offset: number,
+  selector: CommentAnnotation['selector'],
   contents: string
 ) {
+  if (!selector) {
+    return ''
+  }
+
   const parts = [
-    contents.substring(0, offset),
+    contents.substring(0, selector.from),
     element.outerHTML,
-    contents.substring(offset),
+    contents.substring(selector.to),
   ]
 
   return parts.join('')
@@ -170,12 +174,16 @@ function injectHighlightMarker(
 
 const createHighlightElement = (
   comment: CommentAnnotation,
-  position: string
+  position: string,
+  content?: string
 ) => {
   const element = document.createElement('span')
   element.className = 'highlight-marker'
   element.setAttribute('id', comment._id)
   element.setAttribute('data-target-id', comment.target)
   element.setAttribute('data-position', position)
+  if (content) {
+    element.innerHTML = content
+  }
   return element
 }


### PR DESCRIPTION
Adding highlighted text of comment between two **highlightMarker** nodes will lead to adding a normal text between them in the editor or if the user hits enter in that range the new node will have the **highlightMarker** node as described in the issue LEAN-3509. this PR will wrap highlighted text in **highlightMarker** node so we can show it as a static entity like citation,link node.   