### PR TITLE
rids should be separated by space - LEAN-3144

### DIFF
--- a/src/schema/nodes/inline_footnote.ts
+++ b/src/schema/nodes/inline_footnote.ts
@@ -54,7 +54,7 @@ export const inlineFootnote: NodeSpec = {
     const footnoteNode = node as InlineFootnoteNode
     const dom = document.createElement('span')
     dom.className = 'footnote'
-    dom.setAttribute('data-reference-id', footnoteNode.attrs.rids.join(''))
+    dom.setAttribute('data-reference-id', footnoteNode.attrs.rids.join(' '))
     dom.textContent = footnoteNode.attrs.contents
 
     return dom


### PR DESCRIPTION
It's failing to validate constructed xml because rids are not separated.