### PR TITLE
disable lift/join to general_table_footnote and footnote node (LEAN-5905)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/transform",
   "description": "ProseMirror transformer for Manuscripts applications",
-  "version": "4.4.6",
+  "version": "4.4.7-LEAN-5905.0",
   "repository": "github:Atypon-OpenSource/manuscripts-transform",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/schema/nodes/footnote.ts
+++ b/src/schema/nodes/footnote.ts
@@ -38,6 +38,7 @@ export interface FootnoteNode extends ManuscriptNode {
 export const footnote: NodeSpec = {
   group: 'block',
   content: 'paragraph+',
+  isolating: true,
   attrs: {
     id: { default: '' },
     kind: { default: 'footnote' },

--- a/src/schema/nodes/general_table_footnote.ts
+++ b/src/schema/nodes/general_table_footnote.ts
@@ -28,6 +28,7 @@ export interface GeneralTableFootnoteNode extends ManuscriptNode {
 
 export const generalTableFootnote: NodeSpec = {
   content: 'paragraph*',
+  isolating: true,
   attrs: {
     id: { default: '' },
     dataTracked: { default: null },


### PR DESCRIPTION
This PR will disable join to footnote node as we have a dedicated delete button to remove them properly with their references. also the same will be for the `general_table_footnote`

[Screencast from 2026-07-30 21-15-49.webm](https://github.com/user-attachments/assets/100276b9-d805-4d09-ab18-c563a210403d)
